### PR TITLE
Support specifying app_token when creating a message

### DIFF
--- a/gotify/async_gotify.py
+++ b/gotify/async_gotify.py
@@ -344,6 +344,8 @@ class AsyncGotify:
                     file=file,
                     method=method,
                     auth_mode=auth_mode,
+                    app_token=app_token,
+                    client_token=client_token,
                 )
 
         if data:

--- a/gotify/errors.py
+++ b/gotify/errors.py
@@ -1,4 +1,5 @@
 """Error classes for gotify."""
+
 import httpx
 
 from .response_types import Error

--- a/gotify/gotify.py
+++ b/gotify/gotify.py
@@ -306,6 +306,8 @@ class Gotify:
                     file=file,
                     method=method,
                     auth_mode=auth_mode,
+                    app_token=app_token,
+                    client_token=client_token,
                 )
 
         if data:

--- a/gotify/response_types.py
+++ b/gotify/response_types.py
@@ -2,6 +2,7 @@
 
 Based on https://gotify.net/api-docs?urls.primaryName=v2.4.0.
 """
+
 from typing import Optional, TypedDict
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,8 @@ def run_test_server():
             "x86_64": "amd64",
             "armv7l": "arm-7",
             "aarch64": "arm64",
-        }[platform.machine()]
+            "amd64": "amd64",
+        }[platform.machine().lower()]
     except KeyError as err:
         raise Exception(
             f"Your architecture '{platform.machine()}' seems to be unsupported"


### PR DESCRIPTION
Support specifying app_token when creating a message

1. support specifying app_token when creating a message
2. conftest supports amd64

nox test result:

```
nox > Running session format
nox > Creating virtual environment (virtualenv) using python.exe in .nox\format
nox > python -m pip install black isort
nox > isort .
Skipped 4 files
nox > black .
All done! ✨ 🍰 ✨
9 files left unchanged.
nox > Session format was successful.
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python.exe in .nox\lint
nox > python -m pip install ruff
nox > ruff check .
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'pydocstyle' -> 'lint.pydocstyle'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
All checks passed!
nox > Session lint was successful.
nox > Running session mypy
nox > Creating virtual environment (virtualenv) using python.exe in .nox\mypy
nox > python -m pip install '.[stream,test]' mypy
nox > mypy 
Success: no issues found in 8 source files
nox > Session mypy was successful.
nox > Running session test-3.9
nox > Missing interpreters will error by default on CI systems.
nox > Session test-3.9 skipped: Python interpreter 3.9 not found.
nox > Running session test-3.10
nox > Creating virtual environment (virtualenv) using python.EXE in .nox\test-3-10
nox > python -m pip install -e '.[stream,test]'
nox > pytest --cov --cov-report=xml --cov-report=term
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.10.11, pytest-8.3.1, pluggy-1.5.0
rootdir: E:\code\gitee\python\python-gotify
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.4.0, asyncio-0.23.8, cov-5.0.0, typeguard-4.3.0
asyncio: mode=auto
collected 55 items                                                                                                                                                                                                                     

tests\test_async_gotify.py ............................                                                                                                                                                                          [ 50%]
tests\test_gotify.py ...........................                                                                                                                                                                                 [100%]

---------- coverage: platform win32, python 3.10.11-final-0 ----------
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
gotify\__init__.py             5      0   100%
gotify\async_gotify.py       131      6    95%   265, 269, 273, 277, 281, 285
gotify\errors.py              14      0   100%
gotify\gotify.py             121      6    95%   260, 264, 268, 272, 276, 280
gotify\response_types.py      58      0   100%
--------------------------------------------------------
TOTAL                        329     12    96%
Coverage XML written to file coverage.xml


========================================================================================================= 55 passed in 9.26s ========================================================================================================== 
nox > Session test-3.10 was successful.
nox > Running session test-3.11
nox > Creating virtual environment (virtualenv) using python.exe in .nox\test-3-11
nox > python -m pip install -e '.[stream,test]'
nox > pytest --cov --cov-report=xml --cov-report=term
========================================================================================================= test session starts =========================================================================================================
platform win32 -- Python 3.11.7, pytest-8.3.1, pluggy-1.5.0
rootdir: E:\code\gitee\python\python-gotify
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.4.0, asyncio-0.23.8, cov-5.0.0, typeguard-4.3.0
asyncio: mode=Mode.AUTO
collected 55 items                                                                                                                                                                                                                     

tests\test_async_gotify.py ............................                                                                                                                                                                          [ 50%]
tests\test_gotify.py ...........................                                                                                                                                                                                 [100%]

---------- coverage: platform win32, python 3.11.7-final-0 -----------
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
gotify\__init__.py             5      0   100%
gotify\async_gotify.py       131      6    95%   265, 269, 273, 277, 281, 285
gotify\errors.py              14      0   100%
gotify\gotify.py             121      6    95%   260, 264, 268, 272, 276, 280
gotify\response_types.py      58      0   100%
--------------------------------------------------------
TOTAL                        329     12    96%
Coverage XML written to file coverage.xml


========================================================================================================= 55 passed in 19.97s ========================================================================================================= 
nox > Session test-3.11 was successful.
nox > Running session test-3.12
nox > Missing interpreters will error by default on CI systems.
nox > Session test-3.12 skipped: Python interpreter 3.12 not found.
nox > Ran multiple sessions:
nox > * format: success
nox > * lint: success
nox > * mypy: success
nox > * test-3.9: skipped
nox > * test-3.10: success
nox > * test-3.11: success
nox > * test-3.12: skipped

```